### PR TITLE
Fix persistence config in status store

### DIFF
--- a/src/stores/status.ts
+++ b/src/stores/status.ts
@@ -152,7 +152,6 @@ export const useStatusStore = defineStore("status", {
       "playRate",
       "playVolume",
       "playVolumeMute",
-      "playSongType",
       "playSongMode",
       "songCoverTheme",
       "listSort",


### PR DESCRIPTION
## Summary
- remove stray `playSongType` from store persistence options

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'electron-vite/node')*

------
https://chatgpt.com/codex/tasks/task_b_683c329509b8832fb5b471ee002c7b1c